### PR TITLE
fix: include shared module in forecast and trading containers

### DIFF
--- a/Dockerfile.forecast
+++ b/Dockerfile.forecast
@@ -43,6 +43,7 @@ RUN which uv && uv --version
 COPY pyproject.toml ./
 COPY forecast/ ./forecast/
 COPY orchestration/ ./orchestration/
+COPY shared/ ./shared/
 COPY .env .env
 
 # Install base dependencies with forecasting extras (includes uvicorn, fastapi, etc.)

--- a/Dockerfile.trading
+++ b/Dockerfile.trading
@@ -29,6 +29,7 @@ RUN which uv && uv --version
 # Copy project files
 COPY pyproject.toml ./
 COPY trading/ ./trading/
+COPY shared/ ./shared/
 
 # Install base dependencies with trading extras (includes uvicorn, fastapi, etc.)
 RUN uv pip install --system --no-cache -e ".[trading]"


### PR DESCRIPTION
### Description
This PR addresses an issue where the `shared` module was missing from both the [forecast](cci:7://file:///home/rafaelkovashikawa/sapheneia/Dockerfile.forecast:0:0-0:0) and [trading](cci:7://file:///home/rafaelkovashikawa/sapheneia/Dockerfile.trading:0:0-0:0) Docker containers, preventing them from starting up cleanly.

### Changes
- Updated [Dockerfile.forecast](cci:7://file:///home/rafaelkovashikawa/sapheneia/Dockerfile.forecast:0:0-0:0) to copy the `shared/` directory during the image build.
- Updated [Dockerfile.trading](cci:7://file:///home/rafaelkovashikawa/sapheneia/Dockerfile.trading:0:0-0:0) to copy the `shared/` directory during the image build.

### Testing
- Built the containers locally using `podman-compose up -d --build forecast forecast-chronos-t5-tiny trading`.
- Verified the containers' health checks pass and the services are reachable.
- Successfully ran an end-to-end inference request against the API payload.
