### PR TITLE
feat: Decouple Model Containers to Support GPU (CUDA) Inference

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,6 +8,10 @@
 #   # Edit .env with your specific values
 #   podman-compose up -d
 
+# Docker Compose Profiles Configuration
+# By default we start in cpu profile. Run with --profile gpu to spin up GPU variants.
+COMPOSE_PROFILES=cpu
+
 # =============================================================================
 # API CONFIGURATION
 # =============================================================================

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,85 @@
+# Sapheneia API Dockerfile (GPU Accelerated)
+# FastAPI backend for time series forecasting - supports multiple models
+#
+# Build args:
+#   MODEL_NAME: Name of the model to run (default: all models via main API)
+#   MODEL_PORT: Port to expose (default: 8000)
+#
+# Examples:
+#   docker build -f Dockerfile.gpu -t sapheneia-api-gpu .
+
+FROM docker.io/nvidia/cuda:12.1.1-runtime-ubuntu22.04
+
+# Build arguments
+ARG MODEL_NAME=all
+ARG MODEL_PORT=8000
+
+# Set as environment variables
+ENV MODEL_NAME=${MODEL_NAME}
+ENV MODEL_PORT=${MODEL_PORT}
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+LABEL maintainer="Sapheneia Team"
+LABEL description="Sapheneia Forecasting API (GPU) - Model: ${MODEL_NAME}"
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    python3.11 \
+    python3.11-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Map python to python3.11
+RUN ln -s /usr/bin/python3.11 /usr/bin/python
+
+# Install uv package manager
+ENV UV_HOME=/usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    mv /root/.cargo/bin/uv /usr/local/bin/uv 2>/dev/null || \
+    mv /root/.local/bin/uv /usr/local/bin/uv 2>/dev/null || true
+
+# Verify uv is installed
+RUN which uv && uv --version
+
+# Copy project files
+COPY pyproject.toml ./
+COPY forecast/ ./forecast/
+COPY orchestration/ ./orchestration/
+COPY .env .env
+
+# Install base dependencies with forecasting extras (includes uvicorn, fastapi, etc.)
+RUN uv pip install --system --no-cache -e ".[forecasting]"
+
+# Install model-specific dependencies based on MODEL_NAME
+# Explicitly use cu121 index for Torch
+RUN if [ "$MODEL_NAME" = "timesfm20" ] || [ "$MODEL_NAME" = "all" ]; then \
+        echo "Installing TimesFM GPU dependencies..." && \
+        uv pip install --system --no-cache torch --extra-index-url https://download.pytorch.org/whl/cu121; \
+    fi
+
+# Install Chronos dependencies
+RUN if [ "$MODEL_NAME" = "chronos" ] || [ "$MODEL_NAME" = "all" ]; then \
+        echo "Installing Chronos GPU dependencies..." && \
+        uv pip install --system --no-cache torch git+https://github.com/amazon-science/chronos-forecasting.git --extra-index-url https://download.pytorch.org/whl/cu121; \
+    fi
+
+# Create necessary directories for all models
+RUN mkdir -p \
+    forecast/models/timesfm20/local \
+    forecast/models/chronos/local \
+    data/uploads \
+    logs
+
+# Expose the specified port
+EXPOSE ${MODEL_PORT}
+
+# Health check - adjust port based on MODEL_PORT
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -f http://localhost:${MODEL_PORT}/health || exit 1
+
+# Run API server on specified port
+CMD ["uvicorn", "forecast.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
   # FastAPI Backend - Forecast API Gateway (routes to all models)
   # NOTE: Uses module-level state - MUST run with single worker (UVICORN_WORKERS=1)
   forecast:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -59,6 +60,7 @@ services:
   # ===========================================================================
 
   forecast-chronos-t5-tiny:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -92,6 +94,7 @@ services:
       start_period: 60s
 
   forecast-chronos-t5-mini:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -125,6 +128,7 @@ services:
       start_period: 60s
 
   forecast-chronos-t5-small:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -158,6 +162,7 @@ services:
       start_period: 60s
 
   forecast-chronos-t5-base:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -191,6 +196,7 @@ services:
       start_period: 60s
 
   forecast-chronos-t5-large:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -228,6 +234,7 @@ services:
   # ===========================================================================
 
   forecast-chronos-bolt-mini:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -261,6 +268,7 @@ services:
       start_period: 60s
 
   forecast-chronos-bolt-small:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -294,6 +302,7 @@ services:
       start_period: 60s
 
   forecast-chronos-bolt-base:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.forecast
@@ -366,6 +375,380 @@ services:
   # UI Service
   # ===========================================================================
 
+  forecast-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: all
+        MODEL_PORT: 8000
+    container_name: sapheneia-forecast-gpu
+    ports:
+      - "${ORCHESTRATION_PORT:-12700}:8000"
+    env_file:
+      - .env
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=all
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+      # URLs for dedicated model containers (used by orchestration service)
+      - CHRONOS_SERVICE_URL=${CHRONOS_SERVICE_URL:-http://forecast-chronos-t5-tiny:8000}
+      - TIMESFM_SERVICE_URL=${TIMESFM_SERVICE_URL:-http://forecast-timesfm:8000}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./data:/app/data
+      - ./logs:/app/logs
+      - ./simulations:/app/simulations
+      - forecast_models_timesfm20:/app/forecast/models/timesfm20/local
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-t5-tiny-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-t5-tiny-gpu
+    ports:
+      - "${CHRONOS_T5_TINY_PORT:-12710}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-t5-tiny
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-t5-mini-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-t5-mini-gpu
+    ports:
+      - "${CHRONOS_T5_MINI_PORT:-12711}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-t5-mini
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-t5-small-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-t5-small-gpu
+    ports:
+      - "${CHRONOS_T5_SMALL_PORT:-12712}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-t5-small
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-t5-base-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-t5-base-gpu
+    ports:
+      - "${CHRONOS_T5_BASE_PORT:-12713}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-t5-base
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-t5-large-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-t5-large-gpu
+    ports:
+      - "${CHRONOS_T5_LARGE_PORT:-12714}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-t5-large
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-bolt-mini-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-bolt-mini-gpu
+    ports:
+      - "${CHRONOS_BOLT_MINI_PORT:-12715}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-bolt-mini
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-bolt-small-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-bolt-small-gpu
+    ports:
+      - "${CHRONOS_BOLT_SMALL_PORT:-12716}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-bolt-small
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  forecast-chronos-bolt-base-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        MODEL_NAME: chronos
+        MODEL_PORT: 8000
+    container_name: forecast-chronos-bolt-base-gpu
+    ports:
+      - "${CHRONOS_BOLT_BASE_PORT:-12717}:8000"
+    environment:
+      - API_HOST=0.0.0.0
+      - API_PORT=8000
+      - MODEL_NAME=chronos
+      - MODEL_VARIANT=amazon/chronos-bolt-base
+      - HF_HOME=/models_cache
+      - DEVICE=cuda:0
+      - PYTHONPATH=/app
+      - API_SECRET_KEY=${API_SECRET_KEY}
+    volumes:
+      - ./forecast:/app/forecast
+      - ./logs:/app/logs
+      - ${MODELS_CACHE_PATH:-./models_cache}:/models_cache
+    networks:
+      - aleutian-network
+    restart: "no"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
   ui:
     build:
       context: .
@@ -385,6 +768,10 @@ services:
     depends_on:
       forecast:
         condition: service_healthy
+        required: false
+      forecast-gpu:
+        condition: service_healthy
+        required: false
     networks:
       - aleutian-network
     restart: unless-stopped


### PR DESCRIPTION
# feat: Decouple Model Containers to Support GPU (CUDA) Inference

Fixes #54

This PR introduces a decoupled, profile-based Docker orchestration to allow developers and production environments to seamlessly leverage GPU-accelerated PyTorch models (TiRex, Chronos, TimesFM) without breaking the default lightweight orchestration ecosystem.

### Frictionless Integration
- **Backwards Compatibility**: CPU is preserved as the default via `COMPOSE_PROFILES=cpu` in the `.env.template`. Developers on standard laptops running `podman-compose up` will see no change and continue utilizing the lightweight `python:3.11-slim` images without NVIDIA driver bloat or missing hardware crashes.
- **Opt-in GPU Acceleration**: When hardware acceleration is needed for heavy inference workloads, users simply run `podman-compose --profile gpu up --build`. The orchestrator intelligently layers the GPU bindings (`cuda:0` device reservations, NVIDIA drivers) into the stack.
 
### Changes
- Implements `Dockerfile.gpu` explicitly leveraging `cu121` PyTorch wheels on an `nvidia/cuda:12.1.1-runtime-ubuntu22.04` base.
- Duplicated Chronos and standard forecast models under the `gpu` profile bypassing port and container name collisions."